### PR TITLE
Fix incorrect computed state when remote player loads avatar faster than their wearer

### DIFF
--- a/Assets/Hai/Just1Int7Toggles/Scripts/Editor/Internal/ViewCreator.cs
+++ b/Assets/Hai/Just1Int7Toggles/Scripts/Editor/Internal/ViewCreator.cs
@@ -36,7 +36,7 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
                 .WithAnimation(CreateBlendTree())
                 .WithWriteDefaultsSetTo(true) // FIXME: Why do I have to do this for the system to work?
                 .Drives(AlwaysOneParameterist, 1f);
-            
+
             {
                 var defaultStageValue = Just1Int7TogglesCompilerInternal.LayerASignalThreshold;
                 for (var exponent = 0; exponent < Just1Int7TogglesCompilerInternal.ExponentCountForLayerA; exponent++)
@@ -51,7 +51,7 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
                 local.Drives(MainParameterist, defaultStageValue);
                 remote.Drives(DirtyCheckParameterist, 1);
             }
-            
+
             if (_alsoGenerateLayerB)
             {
                 var defaultStageValue = 0;
@@ -69,17 +69,19 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
             }
 
             init.TransitionsTo(local).Whenever(ItIsLocal());
-            init.TransitionsTo(remote).Whenever(ItIsRemote());
+            init.TransitionsTo(remote)
+                .Whenever(ItIsRemote())
+                .And(MainParameterist).IsGreaterThan(Just1Int7TogglesCompilerInternal.LayerASignalThreshold - 1); // Wait until synchronization
             local.AutomaticallyMovesTo(blend);
             remote.AutomaticallyMovesTo(blend);
         }
-        
+
         private Motion CreateBlendTree()
         {
             var assetContainer_Base = new AnimatorController();
             var assetContainer = new AssetContainerist(assetContainer_Base)
                 .GenerateAssetFileIn("", "GeneratedJ1I7T__", "");
-            
+
             var childMotions = new List<ChildMotion>();
             for (var exponent = 0; exponent < Just1Int7TogglesCompilerInternal.ExponentCountForLayerA; exponent++)
             {
@@ -124,7 +126,7 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
                 .ToDictionary(items => items.Key, items => items.First().initialState);
 
             if (group.Count == 0) return;
-            
+
             var clipForOn = CreateClipToEnable(itemNumber, group);
             var clipForOff = CreateClipToDisable(itemNumber, group);
 
@@ -179,7 +181,7 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
             var motionist = Motionist.FromScratch()
                 .WithName("Enable " + itemNumber)
                 .NonLooping();
-            
+
             foreach (var path in relativePaths)
             {
                 switch (path.Value)


### PR DESCRIPTION
When a wearer changes avatar, if a remote player loads an avatar faster than their wearer, then it is possible that the remote player will try to evaluate the avatar inventory state with an unpredictable value of the avatar for a given parameter.

This unpredictable value seems to be equal to 0 when a player joins a world. This means that if a remote player loads the avatar faster than the wearer, all of the toggles will be evaluated as being off, causing all items or avatar features to disappear.

The current attempted fix is:

- In the View, if the player is remote, then only flag for dirty checks after the `J1I7T_A_Sync` parameter is strictly greater than 127. This conditions becomes true when the avatar wearer actually driver the sync state when they have loaded the avatar and reached the "Local SetSyncValue" in the View.
- In the Transmitters, all intermediate remote transitions to a low bit state will also require  `J1I7T_A_Sync` parameter to be strictly greater than 127. This will temporarily suspend evaluation of the binary tree if the avatar wearer happened to be in the middle of changing avatar toggles again while the binary tree was being evaluated remotely.

Closes #4