### PR TITLE
Fix zero items visible for a split second

### DIFF
--- a/Assets/Hai/Just1Int7Toggles/Scripts/Editor/Internal/ViewCreator.cs
+++ b/Assets/Hai/Just1Int7Toggles/Scripts/Editor/Internal/ViewCreator.cs
@@ -73,7 +73,18 @@ namespace Hai.Just1Int7Toggles.Scripts.Editor.Internal
                 .Whenever(ItIsRemote())
                 .And(MainParameterist).IsGreaterThan(Just1Int7TogglesCompilerInternal.LayerASignalThreshold - 1); // Wait until synchronization
             local.AutomaticallyMovesTo(blend);
-            remote.AutomaticallyMovesTo(blend);
+
+            if (_alsoGenerateLayerB)
+            {
+                remote.TransitionsTo(blend)
+                    .When(DirtyCheckParameterist).IsEqualTo(0)
+                    .And(DirtyCheckOfBParameterist).IsEqualTo(0);
+            }
+            else
+            {
+                remote.TransitionsTo(blend)
+                    .When(DirtyCheckParameterist).IsEqualTo(0);
+            }
         }
 
         private Motion CreateBlendTree()


### PR DESCRIPTION
When a remote player loads an avatar, the clothes will attempt to blend as soon as the remote player receives the synced value.

However, there is a split second before the received synced value is computed into toggles, causing all the items to disappear for that split duration.

The current fix is to wait for the dirty checks to clear remotely, which is attained when the evaluation completes at the leaves of the transmitter.

Closes #6